### PR TITLE
Build against refactored rdf-core

### DIFF
--- a/rdf/io/json.rkt
+++ b/rdf/io/json.rkt
@@ -16,6 +16,7 @@
          rdf/core/nsmap
          rdf/core/statement
          rdf/core/triple
+         rdf/core/tree
          ;; --------------------------------------
          media-type
          ;; --------------------------------------

--- a/rdf/io/scribblings/rdf-io.scrbl
+++ b/rdf/io/scribblings/rdf-io.scrbl
@@ -10,6 +10,7 @@
                      racket/port
                      rdf/core/dataset
                      rdf/core/graph
+		     rdf/core/nsname
                      rdf/core/statement
                      media-type
                      rdf/io/base
@@ -30,14 +31,15 @@
    (make-base-eval '(require net/url-string
                              rdf/core/graph
                              rdf/core/literal
+			     rdf/core/resource
                              rdf/core/triple
                              rdf/io/base
                              rdf/io/registry)
                    '(define
                      graph-about-me
                      (named-graph
-                      (string->url "http://example.com/my-graph")
-                      (statement-list
+                      (string->resource "http://example.com/my-graph")
+                      (make-statements
                         "http://example.com/p/me"
                         (list (list "http://example.com/v/people#hasFirstName"
                                (list (make-lang-string-literal "Me" "en")))

--- a/rdf/io/tests/data.rkt
+++ b/rdf/io/tests/data.rkt
@@ -11,7 +11,8 @@
          rdf/core/graph
          rdf/core/io
          rdf/core/literal
-         rdf/core/namespace
+         rdf/core/nsname
+         rdf/core/resource
          rdf/core/triple
          rdf/core/v/rdf
          ;; --------------------------------------
@@ -25,18 +26,18 @@
 (define *example-typed-literal*
   (make-typed-literal
    "42"
-   (string->url "http://www.w3.org/2001/XMLSchema#integer")))
+   (string->resource "http://www.w3.org/2001/XMLSchema#integer")))
 
 (define *empty-dataset* (unnamed-dataset (make-hash)))
 
 (define *empty-graph* (unnamed-graph '()))
 
-(define *empty-named-graph* (named-graph (string->url "http://example.org/example/named") '()))
+(define *empty-named-graph* (named-graph (string->resource "http://example.org/example/named") '()))
 
 (define *example-graph-1*
   (named-graph
-   (string->url "http://example.com/peeps")
-   (statement-list
+   (string->resource "http://example.com/peeps")
+   (make-statements
     "http://example.com/p/me"
     (list (list "http://example.com/v/people#hasFirstName"
                 (list *example-language-literal*))
@@ -47,7 +48,7 @@
 
 (define *example-unnamed-graph-1*
   (unnamed-graph
-   (statement-list
+   (make-statements
     "http://example.com/p/me"
     (list (list "http://example.com/v/people#hasFirstName"
                 (list *example-language-literal*))
@@ -58,9 +59,9 @@
 
 (define *example-type-statement*
   (triple
-   (string->url "http://example.com/peeps")
-   (nsname->url rdf:type)
-   (string->url "http://xmlns.com/foaf/0.1/Person")))
+   (string->resource "http://example.com/peeps")
+   (nsname->resource rdf:type)
+   (string->resource "http://xmlns.com/foaf/0.1/Person")))
 
 (define (check-reader test-data-file repr-id (expected #f))
   (let* ((representation (get-representation repr-id))

--- a/rdf/io/tests/ntriples.rkt
+++ b/rdf/io/tests/ntriples.rkt
@@ -6,6 +6,7 @@
          net/url-string
          ;; --------------------------------------
          rdf/core/literal
+         rdf/core/resource
          rdf/core/statement
          rdf/core/triple
          ;; --------------------------------------
@@ -33,9 +34,9 @@
       'ntriples
       (list
        (triple
-        (string->url "http://example.com/p/me")
-        (string->url "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-        (string->url "http://xmlns.com/foaf/0.1/Person")))))
+        (string->resource "http://example.com/p/me")
+        (string->resource "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        (string->resource "http://xmlns.com/foaf/0.1/Person")))))
 
     (test-case
        "read Blank-URI-URI"
@@ -45,8 +46,8 @@
       (list
        (triple
         (make-blank-node "B1234")
-        (string->url "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-        (string->url "http://xmlns.com/foaf/0.1/Person")))))
+        (string->resource "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        (string->resource "http://xmlns.com/foaf/0.1/Person")))))
 
    (test-case
        "read URI-URI-Blank"
@@ -55,8 +56,8 @@
       'ntriples
       (list
        (triple
-        (string->url "http://example.com/p/me")
-        (string->url "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        (string->resource "http://example.com/p/me")
+        (string->resource "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
         (make-blank-node "B1234")))))
 
    (test-case
@@ -66,8 +67,8 @@
       'ntriples
       (list
        (triple
-        (string->url "http://example.com/p/me")
-        (string->url "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        (string->resource "http://example.com/p/me")
+        (string->resource "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
         (make-untyped-literal "Person")))))
 
    (test-case
@@ -77,8 +78,8 @@
       'ntriples
       (list
        (triple
-        (string->url "http://example.com/p/me")
-        (string->url "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        (string->resource "http://example.com/p/me")
+        (string->resource "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
         (make-lang-string-literal "Person" "en")))))
 
    (test-case
@@ -88,9 +89,9 @@
       'ntriples
       (list
        (triple
-        (string->url "http://example.com/p/me")
-        (string->url "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-        (make-typed-literal "Person" (string->url "http://www.w3.org/2001/XMLSchema#string"))))))))
+        (string->resource "http://example.com/p/me")
+        (string->resource "http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+        (make-typed-literal "Person" (string->resource "http://www.w3.org/2001/XMLSchema#string"))))))))
 
 (define ntriples-write-test-suite
   (test-suite

--- a/rdf/io/tests/xml.rkt
+++ b/rdf/io/tests/xml.rkt
@@ -10,8 +10,9 @@
          rdf/core/dataset
          rdf/core/graph
          rdf/core/literal
-         rdf/core/namespace
+         rdf/core/nsname
          rdf/core/nsmap
+         rdf/core/resource
          rdf/core/statement
          rdf/core/triple
          rdf/core/v/rdf
@@ -375,11 +376,11 @@ EOXML
 EOXML
       2
       (list
-       (triple (string->url "http://example.org/thing")
-               (nsname->url rdf:type)
-               (string->url "http://example.org/stuff/1.0/Document"))
-       (triple (string->url "http://example.org/thing")
-               (string->url "http://purl.org/dc/elements/1.1/title")
+       (triple (string->resource "http://example.org/thing")
+               (nsname->resource rdf:type)
+               (string->resource "http://example.org/stuff/1.0/Document"))
+       (triple (string->resource "http://example.org/thing")
+               (string->resource "http://purl.org/dc/elements/1.1/title")
                (make-untyped-literal "A marvelous thing")))))
 
    (test-case
@@ -399,11 +400,11 @@ EOXML
 EOXML
       2
       (list
-       (triple (string->url "http://example.org/thing")
-               (nsname->url rdf:type)
-               (string->url "http://example.org/stuff/1.0/Document"))
-       (triple (string->url "http://example.org/thing")
-               (string->url "http://purl.org/dc/elements/1.1/title")
+       (triple (string->resource "http://example.org/thing")
+               (nsname->resource rdf:type)
+               (string->resource "http://example.org/stuff/1.0/Document"))
+       (triple (string->resource "http://example.org/thing")
+               (string->resource "http://purl.org/dc/elements/1.1/title")
                (make-untyped-literal "A marvelous thing")))))
 
    (test-case
@@ -424,9 +425,9 @@ EOXML
       1
       (list
        (triple
-        (string->url "http://example.org/here/#snack")
-        (string->url "http://example.org/stuff/1.0/prop")
-        (string->url "http://example.org/here/fruit/apple")))))
+        (string->resource "http://example.org/here/#snack")
+        (string->resource "http://example.org/stuff/1.0/prop")
+        (string->resource "http://example.org/here/fruit/apple")))))
 
    (test-case
        "Spec Example 17"
@@ -444,11 +445,11 @@ EOXML
 </rdf:RDF>
 EOXML
       4
-      (let ((subject (string->url "http://example.org/favourite-fruit")))
-        (list (triple subject (nsname->url rdf:type) (nsname->url rdf:Seq))
-              (triple subject (nsname->url (rdf:_ 1)) (string->url "http://example.org/banana"))
-              (triple subject (nsname->url (rdf:_ 2)) (string->url "http://example.org/apple"))
-              (triple subject (nsname->url (rdf:_ 3)) (string->url "http://example.org/pear"))))))
+      (let ((subject (string->resource "http://example.org/favourite-fruit")))
+        (list (triple subject (nsname->resource rdf:type) (nsname->resource rdf:Seq))
+              (triple subject (nsname->resource (rdf:_ 1)) (string->resource "http://example.org/banana"))
+              (triple subject (nsname->resource (rdf:_ 2)) (string->resource "http://example.org/apple"))
+              (triple subject (nsname->resource (rdf:_ 3)) (string->resource "http://example.org/pear"))))))
 
    (test-case
        "Spec Example 18"
@@ -466,11 +467,11 @@ EOXML
 </rdf:RDF>
 EOXML
       4
-      (let ((subject (string->url "http://example.org/favourite-fruit")))
-        (list (triple subject (nsname->url rdf:type) (nsname->url rdf:Seq))
-              (triple subject (nsname->url rdf:li) (string->url "http://example.org/banana"))
-              (triple subject (nsname->url rdf:li) (string->url "http://example.org/apple"))
-              (triple subject (nsname->url rdf:li) (string->url "http://example.org/pear"))))))
+      (let ((subject (string->resource "http://example.org/favourite-fruit")))
+        (list (triple subject (nsname->resource rdf:type) (nsname->resource rdf:Seq))
+              (triple subject (nsname->resource rdf:li) (string->resource "http://example.org/banana"))
+              (triple subject (nsname->resource rdf:li) (string->resource "http://example.org/apple"))
+              (triple subject (nsname->resource rdf:li) (string->resource "http://example.org/pear"))))))
 
    (test-case
        "Spec Example 19"


### PR DESCRIPTION
Many thanks for your work on both this and the RDF core library! I've been using these for n-triples and they've been working really well.  These are changes which get `rdf-io` to build.

It seemed to mostly be a matter of renamed modules and references to `->url` functions (&c). This *seems* to work and the tests appear to pass. I haven't had any problems so far, mostly working in the REPL, using the source code as documentation.

One thing to emphasise. There used to be a function called `url->namespace`. As far as I can tell, the equivalent is `resource-namespace` (but this is potentially wrong). Further, there was no equivalent of `namespace->string` but I feel comfortable with loosely defining it as composition of two functions.